### PR TITLE
remove si.type checking when parsing swing tags

### DIFF
--- a/src/ir_decoder/src/ir_ac_control.c
+++ b/src/ir_decoder/src/ir_ac_control.c
@@ -104,7 +104,6 @@ INT8 ir_ac_lib_parse()
             continue;
         }
         // then parse TAG 26 or 33
-        if (context->si.type == SWING_TYPE_NORMAL)
         {
             UINT16 swing_space_size = 0;
             if (tags[i].tag == TAG_AC_SWING_1)


### PR DESCRIPTION
this checking should not be there.